### PR TITLE
fix use web console default

### DIFF
--- a/.changeset/chilly-scissors-end.md
+++ b/.changeset/chilly-scissors-end.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Fix an issue where Terraform would prompt to set the 'use_web_console_for_approval_action' to null each plan/apply.

--- a/.changeset/friendly-ads-beg.md
+++ b/.changeset/friendly-ads-beg.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": minor
+---
+
+Add support for configuring the Terraform provider entirely via environment variables.

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	config_client "github.com/common-fate/sdk/config"
@@ -59,21 +58,21 @@ func (p *CommonFateProvider) Schema(ctx context.Context, req provider.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"api_url": schema.StringAttribute{
 				Description: "The API url of your Common Fate deployment.",
-				Required:    true,
+				Optional:    true,
 			},
 			"authz_url": schema.StringAttribute{
 				Description: "The base URL of the Common Fate authz service. If not provided, will default to the same URL as the api_url",
 				Optional:    true,
 			},
 			"oidc_client_id": schema.StringAttribute{
-				Required: true,
+				Optional: true,
 			},
 			"oidc_client_secret": schema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
 			},
 			"oidc_issuer": schema.StringAttribute{
-				Required: true,
+				Optional: true,
 			},
 		},
 	}
@@ -89,21 +88,14 @@ func (p *CommonFateProvider) Configure(ctx context.Context, req provider.Configu
 		return
 	}
 
-	clientsecret := config.OIDCClientSecret.ValueString()
-
-	if os.Getenv("CF_OIDC_CLIENT_SECRET") != "" {
-		clientsecret = os.Getenv("CF_OIDC_CLIENT_SECRET")
-	}
-
 	//using context.Background() here causes a cancelled context issue
 	//see https://github.com/databricks/databricks-sdk-go/issues/671
-	cfg, err := config_client.NewServerContext(context.Background(), config_client.Opts{
+	cfg, err := config_client.New(context.Background(), config_client.Opts{
 		APIURL:       config.APIURL.ValueString(),
 		ClientID:     config.OIDCClientId.ValueString(),
-		ClientSecret: clientsecret,
-		// @TODO consider changing this to use a direct issuer env var
-		OIDCIssuer: strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
-		AuthzURL:   config.AuthzURL.ValueString(),
+		ClientSecret: config.OIDCClientSecret.ValueString(),
+		OIDCIssuer:   strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
+		AuthzURL:     config.AuthzURL.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/slack/resource_slack_alert.go
+++ b/internal/slack/resource_slack_alert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -95,6 +96,8 @@ func (r *SlackAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"use_web_console_for_approval_action": schema.BoolAttribute{
 				MarkdownDescription: "Optionally, configure the access request review buttons to be links to the web console, rather than performing the action in Slack.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 		},
 		MarkdownDescription: `Links a Slack message being send to a particular channel or workspace based on actions made against a workflow.`,


### PR DESCRIPTION
- support configuring the Terraform provider entirely via environment variables
- changeset
- fix the default value for the 'use_web_console_for_approval_action' variable
