### PR TITLE
fix the default value for the 'use_web_console_for_approval_action' variable

### DIFF
--- a/.changeset/chilly-scissors-end.md
+++ b/.changeset/chilly-scissors-end.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Fix an issue where Terraform would prompt to set the 'use_web_console_for_approval_action' to null each plan/apply.

--- a/internal/slack/resource_slack_alert.go
+++ b/internal/slack/resource_slack_alert.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -95,6 +96,8 @@ func (r *SlackAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"use_web_console_for_approval_action": schema.BoolAttribute{
 				MarkdownDescription: "Optionally, configure the access request review buttons to be links to the web console, rather than performing the action in Slack.",
 				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 		},
 		MarkdownDescription: `Links a Slack message being send to a particular channel or workspace based on actions made against a workflow.`,


### PR DESCRIPTION
Fixes this message appearing every time `apply` is run:

```
# commonfate_slack_alert.example will be updated in-place
  ~ resource "commonfate_slack_alert" "example" {
        id                                  = "slack_XXXXXX"
      - use_web_console_for_approval_action = false -> null
        # (4 unchanged attributes hidden)
    }
```