### PR TITLE
fix config file does not exist error

### DIFF
--- a/.changeset/unlucky-eggs-rule.md
+++ b/.changeset/unlucky-eggs-rule.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Fix for config file does not exist error

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -92,11 +92,12 @@ func (p *CommonFateProvider) Configure(ctx context.Context, req provider.Configu
 	//using context.Background() here causes a cancelled context issue
 	//see https://github.com/databricks/databricks-sdk-go/issues/671
 	cfg, err := config_client.New(context.Background(), config_client.Opts{
-		APIURL:        config.APIURL.ValueString(),
-		ClientID:      config.OIDCClientId.ValueString(),
-		ClientSecret:  config.OIDCClientSecret.ValueString(),
-		OIDCIssuer:    strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
-		AuthzURL:      config.AuthzURL.ValueString(),
+		APIURL:       config.APIURL.ValueString(),
+		ClientID:     config.OIDCClientId.ValueString(),
+		ClientSecret: config.OIDCClientSecret.ValueString(),
+		OIDCIssuer:   strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
+		AuthzURL:     config.AuthzURL.ValueString(),
+
 		ConfigSources: []string{"env"},
 	})
 	if err != nil {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -92,11 +92,12 @@ func (p *CommonFateProvider) Configure(ctx context.Context, req provider.Configu
 	//using context.Background() here causes a cancelled context issue
 	//see https://github.com/databricks/databricks-sdk-go/issues/671
 	cfg, err := config_client.New(context.Background(), config_client.Opts{
-		APIURL:       config.APIURL.ValueString(),
-		ClientID:     config.OIDCClientId.ValueString(),
-		ClientSecret: config.OIDCClientSecret.ValueString(),
-		OIDCIssuer:   strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
-		AuthzURL:     config.AuthzURL.ValueString(),
+		APIURL:        config.APIURL.ValueString(),
+		ClientID:      config.OIDCClientId.ValueString(),
+		ClientSecret:  config.OIDCClientSecret.ValueString(),
+		OIDCIssuer:    strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
+		AuthzURL:      config.AuthzURL.ValueString(),
+		ConfigSources: []string{"env"},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -92,12 +92,11 @@ func (p *CommonFateProvider) Configure(ctx context.Context, req provider.Configu
 	//using context.Background() here causes a cancelled context issue
 	//see https://github.com/databricks/databricks-sdk-go/issues/671
 	cfg, err := config_client.New(context.Background(), config_client.Opts{
-		APIURL:       config.APIURL.ValueString(),
-		ClientID:     config.OIDCClientId.ValueString(),
-		ClientSecret: config.OIDCClientSecret.ValueString(),
-		OIDCIssuer:   strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
-		AuthzURL:     config.AuthzURL.ValueString(),
-
+		APIURL:        config.APIURL.ValueString(),
+		ClientID:      config.OIDCClientId.ValueString(),
+		ClientSecret:  config.OIDCClientSecret.ValueString(),
+		OIDCIssuer:    strings.TrimSuffix(config.OIDCIssuer.ValueString(), "/"),
+		AuthzURL:      config.AuthzURL.ValueString(),
 		ConfigSources: []string{"env"},
 	})
 	if err != nil {


### PR DESCRIPTION
Fix for: 
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Failed to load config
│ 
│   with provider["registry.terraform.io/common-fate/commonfate"],
│   on main.tf line 44, in provider "commonfate":
│   44: provider "commonfate" {
│ 
│ config file does not exist
```

Tested by replicating the error and testing the fix 