### PR TITLE
Add default duration to access workflows

### DIFF
--- a/.changeset/polite-knives-play.md
+++ b/.changeset/polite-knives-play.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Add default duration to access workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ resource "commonfate_access_workflow" "demo" {
   access_duration_seconds="7200"
   try_extend_after_seconds="3500"
   priority="100"
+  default_duration_seconds="3600"
 }
 
 resource "commonfate_gcp_project_selector" "demo" {

--- a/docs/resources/access_workflow.md
+++ b/docs/resources/access_workflow.md
@@ -29,12 +29,13 @@ resource "commonfate-access_workflow" "workflow-demo" {
 
 ### Required
 
-- `access_duration_seconds` (Number) The duration of the access workflow.
+- `access_duration_seconds` (Number) The maximum allowable duration for the access workflow
 - `try_extend_after_seconds` (Number) The amount of time after access is activated that extending access can be attempted. As a starting point we recommend setting this to half of the `access_duration_seconds`.
 
 ### Optional
 
 - `activation_expiry` (Number) The amount of time after access is activated before the request will be expired
+- `default_duration_seconds` (Number) The default duration of the access workflow
 - `name` (String) A unique name for the workflow so you know how to identify it.
 - `priority` (Number) The priority that governs whether the policy will be used. If a different policy with a higher priority and the same role exists that one will be used over another.
 

--- a/docs/resources/access_workflow.md
+++ b/docs/resources/access_workflow.md
@@ -19,6 +19,7 @@ resource "commonfate-access_workflow" "workflow-demo" {
   access_duration_seconds  = 60 * 60
   try_extend_after_seconds = 10 * 60
   priority                 = "100"
+  default_duration_seconds = 30 * 60
 }
 ```
 

--- a/examples/resources/commonfate_access_workflow/resource.tf
+++ b/examples/resources/commonfate_access_workflow/resource.tf
@@ -3,4 +3,5 @@ resource "commonfate-access_workflow" "workflow-demo" {
   access_duration_seconds  = 60 * 60
   try_extend_after_seconds = 10 * 60
   priority                 = "100"
+  default_duration_seconds = 30 * 60
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.29.0
+	github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233
+	github.com/common-fate/sdk v1.31.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/common-fate/sdk v1.29.0 h1:kPv1jn8eUCf4UosHmDr/EeNB6rUJY2cL1MiSGp1bYe
 github.com/common-fate/sdk v1.29.0/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
 github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233 h1:nV2nWMQcRd2fTLbX+a129zAqRV5mwKYci8rbmTwY4ZU=
 github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
+github.com/common-fate/sdk v1.31.0 h1:0enjoKE/fd2+Qa78sRfQnLNQmikjPWAp4gwubypu7Ag=
+github.com/common-fate/sdk v1.31.0/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/common-fate/grab v1.1.0 h1:HLZPtltdHScYu6qtt/UC78rvwylCTWuyoZoiQXV4QH
 github.com/common-fate/grab v1.1.0/go.mod h1:L0qa03RwqOMZz9PrrWw9eI145i5FQRf+iLtNSJypQvY=
 github.com/common-fate/sdk v1.29.0 h1:kPv1jn8eUCf4UosHmDr/EeNB6rUJY2cL1MiSGp1bYes=
 github.com/common-fate/sdk v1.29.0/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
+github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233 h1:nV2nWMQcRd2fTLbX+a129zAqRV5mwKYci8rbmTwY4ZU=
+github.com/common-fate/sdk v1.30.1-0.20240502030039-0e82e0795233/go.mod h1:GY+u9RSpn25gHbQX8wVuSXjYpyPY8sjohaFUmEGrqqY=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/internal/access/resource_access_workflow.go
+++ b/internal/access/resource_access_workflow.go
@@ -307,6 +307,25 @@ func (r *AccessWorkflowResource) Update(ctx context.Context, req resource.Update
 		data.ActivationExpiry = types.Int64Value(res.Msg.Workflow.ActivationExpiry.Seconds)
 
 	}
+	var defaultDuration time.Duration
+	if !data.DefaultDuration.IsNull() {
+		defaultDuration = time.Second * time.Duration(data.DefaultDuration.ValueInt64())
+
+		if defaultDuration >= accessDuration {
+			resp.Diagnostics.AddError(
+				"Invalid Default Duration",
+				"The default duration must be less than the maximum access duration. "+
+					"Please adjust the Default Duration to be less than Access Duration.\n\n"+
+					"Default Duration: "+defaultDuration.String()+", Access Duration: "+accessDuration.String(),
+			)
+			return
+		}
+		
+	} else {
+		defaultDuration = accessDuration
+	}
+
+	updateReq.Workflow.DefaultDuration = durationpb.New(defaultDuration)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -53,6 +53,7 @@ resource "commonfate_access_workflow" "demo" {
   access_duration_seconds="7200"
   try_extend_after_seconds="3500"
   priority="100"
+  default_duration_seconds="3600"
 }
 
 resource "commonfate_gcp_project_selector" "demo" {


### PR DESCRIPTION
Users can optionally specify a default duration for their access workflows.