### PR TITLE
fix state management for default duration

### DIFF
--- a/internal/access/resource_access_workflow.go
+++ b/internal/access/resource_access_workflow.go
@@ -150,9 +150,8 @@ func (r *AccessWorkflowResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// set default duration to access duration by default
-	defaultDuration := accessDuration
 	if !data.DefaultDuration.IsNull() {
-		defaultDuration = time.Second * time.Duration(data.DefaultDuration.ValueInt64())
+		defaultDuration := time.Second * time.Duration(data.DefaultDuration.ValueInt64())
 
 		if defaultDuration > accessDuration {
 			resp.Diagnostics.AddError(
@@ -163,12 +162,8 @@ func (r *AccessWorkflowResource) Create(ctx context.Context, req resource.Create
 			)
 			return
 		}
-
-	} else {
-		defaultDuration = accessDuration
+		createReq.DefaultDuration = durationpb.New(defaultDuration)
 	}
-
-	createReq.DefaultDuration = durationpb.New(defaultDuration)
 
 	res, err := r.client.CreateAccessWorkflow(ctx, connect.NewRequest(createReq))
 
@@ -286,10 +281,9 @@ func (r *AccessWorkflowResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// set default duration to access duration by default
-	defaultDuration := accessDuration
 	if !data.DefaultDuration.IsNull() {
 
-		defaultDuration = time.Second * time.Duration(data.DefaultDuration.ValueInt64())
+		defaultDuration := time.Second * time.Duration(data.DefaultDuration.ValueInt64())
 		if defaultDuration > accessDuration {
 			resp.Diagnostics.AddError(
 				"Invalid Default Duration",
@@ -299,11 +293,8 @@ func (r *AccessWorkflowResource) Update(ctx context.Context, req resource.Update
 			)
 			return
 		}
-	} else {
-		defaultDuration = accessDuration
+		updateReq.Workflow.DefaultDuration = durationpb.New(defaultDuration)
 	}
-
-	updateReq.Workflow.DefaultDuration = durationpb.New(defaultDuration)
 
 	res, err := r.client.UpdateAccessWorkflow(ctx, connect.NewRequest(updateReq))
 
@@ -329,6 +320,13 @@ func (r *AccessWorkflowResource) Update(ctx context.Context, req resource.Update
 		data.ActivationExpiry = types.Int64Null()
 	} else {
 		data.ActivationExpiry = types.Int64Value(res.Msg.Workflow.ActivationExpiry.Seconds)
+
+	}
+
+	if res.Msg.Workflow.DefaultDuration == nil {
+		data.DefaultDuration = types.Int64Null()
+	} else {
+		data.DefaultDuration = types.Int64Value(res.Msg.Workflow.DefaultDuration.Seconds)
 
 	}
 


### PR DESCRIPTION
![Screenshot 2024-05-13 at 6 11 33 PM](https://github.com/common-fate/terraform-provider-commonfate/assets/33018450/8466e0e5-230a-4378-95be-4d95736b1268)

Fixes an issue where the state would be updated in the app causing a drift from what is set in the terraform config

What was happening was: If default duration was empty in terraform, it was being set to the max duration causing a drift in the terraform config


example: 
resource: 
```
resource "commonfate_access_workflow" "aws1" {
  name                     = "aws"
  access_duration_seconds  = 60 * 60 * 60
  try_extend_after_seconds = 5
  priority                 = 5
}
```
![Screenshot 2024-05-13 at 6 18 47 PM](https://github.com/common-fate/terraform-provider-commonfate/assets/33018450/3469e8cb-2e2e-46f2-8d69-4b5410905a1a)


resource: 
```
resource "commonfate_access_workflow" "aws1" {
  name                     = "aws"
  access_duration_seconds  = 60 * 60 * 60
  try_extend_after_seconds = 5
  priority                 = 5
  default_duration_seconds = 10 * 50
}
```
![Screenshot 2024-05-13 at 6 19 25 PM](https://github.com/common-fate/terraform-provider-commonfate/assets/33018450/3e5e5eef-7b21-458e-8d64-d2772ac9e90e)
