### PR TITLE
Support disabling all webhook handlers for the slack integration

### DIFF
--- a/.changeset/serious-ghosts-refuse.md
+++ b/.changeset/serious-ghosts-refuse.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Support disabling all webhook handlers for the Slack integration.

--- a/.changeset/serious-ghosts-refuse.md
+++ b/.changeset/serious-ghosts-refuse.md
@@ -1,5 +1,5 @@
 ---
-"@common-fate/terraform-provider-commonfate": patch
+"@common-fate/terraform-provider-commonfate": minor
 ---
 
 Support disabling all webhook handlers for the Slack integration.

--- a/docs/resources/slack_alert.md
+++ b/docs/resources/slack_alert.md
@@ -33,6 +33,7 @@ resource "commonfate-slack_alert" "demo" {
 
 ### Optional
 
+- `disable_interactivity_handlers` (Boolean) Disables all webhook handlers for the Slack integration.
 - `integration_id` (String) The ID for the integration set up to slack.
 - `send_direct_message_to_approvers` (Boolean) If Slack is connected, it will send notifications to the requesting user. Cannot be used in conjunction with 'slack_channel_id'
 - `slack_channel_id` (String) If Slack is connected, it will send notifications to this slack channel. Must be the ID of the channel and not the name. See below on how to find this ID.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.36.0
+	github.com/common-fate/sdk v1.36.1
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/common-fate/sdk v1.35.1 h1:JLA0OXzbd7dGBabQ6mlxznIfhZljFSRApawBT6IIL5
 github.com/common-fate/sdk v1.35.1/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/sdk v1.36.0 h1:w29vM99IY0CpUYHYWsBbGYB+o+DXDFXDQUXMTB4ONg8=
 github.com/common-fate/sdk v1.36.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
+github.com/common-fate/sdk v1.36.1 h1:ehrl7QD+EYCFdIc4V+sGaVKpfZb2WG5YSihM+letWgw=
+github.com/common-fate/sdk v1.36.1/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/internal/slack/resource_slack_alert.go
+++ b/internal/slack/resource_slack_alert.go
@@ -27,6 +27,7 @@ type SlackAlertModel struct {
 	SlackWorkspaceID               types.String `tfsdk:"slack_workspace_id"`
 	UseWebConsoleForApprovalAction types.Bool   `tfsdk:"use_web_console_for_approval_action"`
 	SendDirectMessagesToApprovers  types.Bool   `tfsdk:"send_direct_message_to_approvers"`
+	DisableInteractivityHandlers   types.Bool   `tfsdk:"disable_interactivity_handlers"`
 }
 
 // AccessRuleResource is the data source implementation.
@@ -103,6 +104,12 @@ func (r *SlackAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"send_direct_message_to_approvers": schema.BoolAttribute{
 				MarkdownDescription: "If Slack is connected, it will send notifications to the requesting user. Cannot be used in conjunction with 'slack_channel_id'",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"disable_interactivity_handlers": schema.BoolAttribute{
+				MarkdownDescription: "Disables all webhook handlers for the Slack integration.",
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),

--- a/internal/slack/resource_slack_alert.go
+++ b/internal/slack/resource_slack_alert.go
@@ -166,6 +166,7 @@ func (r *SlackAlertResource) Create(ctx context.Context, req resource.CreateRequ
 		SlackWorkspaceId:              data.SlackWorkspaceID.ValueString(),
 		UseWebConsoleForApproveAction: data.UseWebConsoleForApprovalAction.ValueBool(),
 		SendDirectMessagesToApprovers: data.SendDirectMessagesToApprovers.ValueBool(),
+		DisableInteractivityHandlers:  data.DisableInteractivityHandlers.ValueBool(),
 	}
 
 	if !data.SlackChannelID.IsNull() {
@@ -237,6 +238,7 @@ func (r *SlackAlertResource) Read(ctx context.Context, req resource.ReadRequest,
 		SlackIntegrationID:             types.StringPointerValue(res.Msg.Alert.IntegrationId),
 		UseWebConsoleForApprovalAction: types.BoolPointerValue(&res.Msg.Alert.UseWebConsoleForApproveAction),
 		SendDirectMessagesToApprovers:  types.BoolPointerValue(&res.Msg.Alert.SendDirectMessagesToApprovers),
+		DisableInteractivityHandlers:   types.BoolPointerValue(&res.Msg.Alert.DisableInteractivityHandlers),
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -287,6 +289,7 @@ func (r *SlackAlertResource) Update(ctx context.Context, req resource.UpdateRequ
 			SlackWorkspaceId:              data.SlackWorkspaceID.ValueString(),
 			UseWebConsoleForApproveAction: data.UseWebConsoleForApprovalAction.ValueBool(),
 			SendDirectMessagesToApprovers: data.SendDirectMessagesToApprovers.ValueBool(),
+			DisableInteractivityHandlers:  data.DisableInteractivityHandlers.ValueBool(),
 		},
 	}
 


### PR DESCRIPTION
This PR disables all webhook handlers for the slack integration.