### PR TITLE
Add provisioner configuration fields to the AWS and GCP integrations

### DIFF
--- a/.changeset/beige-donuts-fetch.md
+++ b/.changeset/beige-donuts-fetch.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": major
+---
+
+Breaking Change: New required fields on commonfate_gcp_integration and commonfate_aws_idc_integration to support migration away from specifying integration config in the infrastructure configuration.

--- a/.changeset/beige-donuts-fetch.md
+++ b/.changeset/beige-donuts-fetch.md
@@ -1,5 +1,5 @@
 ---
-"@common-fate/terraform-provider-commonfate": major
+"@common-fate/terraform-provider-commonfate": minor
 ---
 
 Breaking Change: New required fields on commonfate_gcp_integration and commonfate_aws_idc_integration to support migration away from specifying integration config in the infrastructure configuration.

--- a/.changeset/beige-donuts-fetch.md
+++ b/.changeset/beige-donuts-fetch.md
@@ -2,4 +2,4 @@
 "@common-fate/terraform-provider-commonfate": minor
 ---
 
-Breaking Change: New required fields on commonfate_gcp_integration and commonfate_aws_idc_integration to support migration away from specifying integration config in the infrastructure configuration.
+Adds new provisioner fields on commonfate_gcp_integration and commonfate_aws_idc_integration to support migration away from specifying integration config in the infrastructure configuration.

--- a/docs/resources/aws_idc_integration.md
+++ b/docs/resources/aws_idc_integration.md
@@ -29,7 +29,6 @@ resource "commonfate_aws_idc_integration" "demo" {
 
 - `identity_store_id` (String) The IAM Identity Center identity store ID
 - `name` (String) The name of the integration: use a short label which is descriptive of the organization you're connecting to
-- `provisioner_role_arn` (String) The ARN of the role to assume in order to provision access in AWS IAM Identity Store
 - `reader_role_arn` (String) The ARN of the role to assume in order to read AWS IAM Identity Store data
 - `sso_instance_arn` (String) The ARN of the IAM Identity Center SSO instance
 - `sso_region` (String) The AWS region that the SSO instance is hosted in
@@ -37,6 +36,7 @@ resource "commonfate_aws_idc_integration" "demo" {
 ### Optional
 
 - `audit_role_name` (String) The name of the role to assume in each AWS Account in order to read resources
+- `provisioner_role_arn` (String) The ARN of the role to assume in order to provision access in AWS IAM Identity Store
 - `resource_regions` (Set of String) The regions to read reasources from in each account
 - `sso_access_portal_url` (String) The SSO access portal URL, e.g https://example.awsapps.com/start
 

--- a/docs/resources/aws_idc_integration.md
+++ b/docs/resources/aws_idc_integration.md
@@ -29,6 +29,7 @@ resource "commonfate_aws_idc_integration" "demo" {
 
 - `identity_store_id` (String) The IAM Identity Center identity store ID
 - `name` (String) The name of the integration: use a short label which is descriptive of the organization you're connecting to
+- `provisioner_role_arn` (String) The ARN of the role to assume in order to provision access in AWS IAM Identity Store
 - `reader_role_arn` (String) The ARN of the role to assume in order to read AWS IAM Identity Store data
 - `sso_instance_arn` (String) The ARN of the IAM Identity Center SSO instance
 - `sso_region` (String) The AWS region that the SSO instance is hosted in

--- a/docs/resources/gcp_integration.md
+++ b/docs/resources/gcp_integration.md
@@ -32,6 +32,8 @@ resource "commonfate_gcp_integration" "demo" {
 
 ### Optional
 
+- `provisioner_service_account_credentials_secret_path` (String) Path to secret for Service account credentials
+- `provisioner_workload_identity_config` (String) GCP Workload Identity Config as a JSON string. If you don't know where to find this, check out our documentation [here](https://enterprise.docs.commonfate.io/deploy)
 - `reader_service_account_credentials_secret_path` (String) Path to secret for Service account credentials
 - `reader_workload_identity_config` (String) GCP Workload Identity Config as a JSON string. If you don't know where to find this, check out our documentation [here](https://enterprise.docs.commonfate.io/deploy)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.36.0
+	github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef
+	github.com/common-fate/sdk v1.37.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/common-fate/sdk v1.36.0 h1:w29vM99IY0CpUYHYWsBbGYB+o+DXDFXDQUXMTB4ONg
 github.com/common-fate/sdk v1.36.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef h1:yD90l/MkN0+HcTuBqYAJaz57EOvl9o49isgGwlf8g9w=
 github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
+github.com/common-fate/sdk v1.37.0 h1:pn4S2MkwbYFglYg5/bMY/55qMclUamui1H1g8/KftkA=
+github.com/common-fate/sdk v1.37.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/common-fate/sdk v1.35.1 h1:JLA0OXzbd7dGBabQ6mlxznIfhZljFSRApawBT6IIL5
 github.com/common-fate/sdk v1.35.1/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/common-fate/sdk v1.36.0 h1:w29vM99IY0CpUYHYWsBbGYB+o+DXDFXDQUXMTB4ONg8=
 github.com/common-fate/sdk v1.36.0/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
+github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef h1:yD90l/MkN0+HcTuBqYAJaz57EOvl9o49isgGwlf8g9w=
+github.com/common-fate/sdk v1.36.1-0.20240528061540-d08fdb43fcef/go.mod h1:WXoPe1Lh7wPmwZj9nXOGVrOU+c5FLUbj7e7Mz4lxSUg=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/internal/aws/resource_aws_idc_integration.go
+++ b/internal/aws/resource_aws_idc_integration.go
@@ -27,6 +27,7 @@ type AWSIDCIntegrationModel struct {
 	AuditRoleName      types.String `tfsdk:"audit_role_name"`
 	ResourceRegions    types.Set    `tfsdk:"resource_regions"`
 	SSOAccessPortalURL types.String `tfsdk:"sso_access_portal_url"`
+	ProvisionerRoleARN types.String `tfsdk:"provisioner_role_arn"`
 }
 
 type AWSIDCIntegrationResource struct {
@@ -98,6 +99,10 @@ func (r *AWSIDCIntegrationResource) Schema(ctx context.Context, req resource.Sch
 				MarkdownDescription: "The ARN of the role to assume in order to read AWS IAM Identity Store data",
 				Required:            true,
 			},
+			"provisioner_role_arn": schema.StringAttribute{
+				MarkdownDescription: "The ARN of the role to assume in order to provision access in AWS IAM Identity Store",
+				Required:            true,
+			},
 			"audit_role_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the role to assume in each AWS Account in order to read resources",
 				Optional:            true,
@@ -156,6 +161,7 @@ func (r *AWSIDCIntegrationResource) Create(ctx context.Context, req resource.Cre
 					IdentityStoreId:    data.IdentityStoreID.ValueString(),
 					SsoRegion:          data.SSORegion.ValueString(),
 					ReaderRoleArn:      data.ReaderRoleARN.ValueString(),
+					ProvisionerRoleArn: data.ProvisionerRoleARN.ValueString(),
 					AuditRoleName:      data.AuditRoleName.ValueString(),
 					ResourceRegions:    resourceRegions,
 					SsoAccessPortalUrl: data.SSOAccessPortalURL.ValueString(),
@@ -252,6 +258,7 @@ func (r *AWSIDCIntegrationResource) Update(ctx context.Context, req resource.Upd
 						IdentityStoreId:    data.IdentityStoreID.ValueString(),
 						SsoRegion:          data.SSORegion.ValueString(),
 						ReaderRoleArn:      data.ReaderRoleARN.ValueString(),
+						ProvisionerRoleArn: data.ProvisionerRoleARN.ValueString(),
 						AuditRoleName:      data.AuditRoleName.ValueString(),
 						ResourceRegions:    resourceRegions,
 						SsoAccessPortalUrl: data.SSOAccessPortalURL.ValueString(),

--- a/internal/aws/resource_aws_idc_integration.go
+++ b/internal/aws/resource_aws_idc_integration.go
@@ -101,7 +101,7 @@ func (r *AWSIDCIntegrationResource) Schema(ctx context.Context, req resource.Sch
 			},
 			"provisioner_role_arn": schema.StringAttribute{
 				MarkdownDescription: "The ARN of the role to assume in order to provision access in AWS IAM Identity Store",
-				Required:            true,
+				Optional:            true,
 			},
 			"audit_role_name": schema.StringAttribute{
 				MarkdownDescription: "The name of the role to assume in each AWS Account in order to read resources",

--- a/internal/gcp/resource_gcp_integration.go
+++ b/internal/gcp/resource_gcp_integration.go
@@ -20,12 +20,14 @@ import (
 )
 
 type GCPIntegrationModel struct {
-	Id                                  types.String `tfsdk:"id"`
-	Name                                types.String `tfsdk:"name"`
-	WorkloadIdentityConfig              types.String `tfsdk:"reader_workload_identity_config"`
-	ServiceAccountCredentialsSecretPath types.String `tfsdk:"reader_service_account_credentials_secret_path"`
-	OrganizationID                      types.String `tfsdk:"organization_id"`
-	GoogleWorkspaceCustomerID           types.String `tfsdk:"google_workspace_customer_id"`
+	Id                                             types.String `tfsdk:"id"`
+	Name                                           types.String `tfsdk:"name"`
+	ReaderWorkloadIdentityConfig                   types.String `tfsdk:"reader_workload_identity_config"`
+	ReaderServiceAccountCredentialsSecretPath      types.String `tfsdk:"reader_service_account_credentials_secret_path"`
+	OrganizationID                                 types.String `tfsdk:"organization_id"`
+	GoogleWorkspaceCustomerID                      types.String `tfsdk:"google_workspace_customer_id"`
+	ProvisionerWorkloadIdentityConfig              types.String `tfsdk:"provisioner_workload_identity_config"`
+	ProvisionerServiceAccountCredentialsSecretPath types.String `tfsdk:"provisioner_service_account_credentials_secret_path"`
 }
 
 type GCPIntegrationResource struct {
@@ -89,6 +91,14 @@ func (r *GCPIntegrationResource) Schema(ctx context.Context, req resource.Schema
 				MarkdownDescription: "Path to secret for Service account credentials",
 				Optional:            true,
 			},
+			"provisioner_workload_identity_config": schema.StringAttribute{
+				MarkdownDescription: "GCP Workload Identity Config as a JSON string. If you don't know where to find this, check out our documentation [here](https://enterprise.docs.commonfate.io/deploy)",
+				Optional:            true,
+			},
+			"provisioner_service_account_credentials_secret_path": schema.StringAttribute{
+				MarkdownDescription: "Path to secret for Service account credentials",
+				Optional:            true,
+			},
 			"organization_id": schema.StringAttribute{
 				MarkdownDescription: "GCP organization ID",
 				Required:            true,
@@ -131,10 +141,12 @@ func (r *GCPIntegrationResource) Create(ctx context.Context, req resource.Create
 		Config: &integrationv1alpha1.Config{
 			Config: &integrationv1alpha1.Config_Gcp{
 				Gcp: &integrationv1alpha1.GCP{
-					ReaderWorkloadIdentityConfig:              data.WorkloadIdentityConfig.ValueString(),
-					ReaderServiceAccountCredentialsSecretPath: data.ServiceAccountCredentialsSecretPath.ValueString(),
-					OrganizationId:                            data.OrganizationID.ValueString(),
-					GoogleWorkspaceCustomerId:                 data.GoogleWorkspaceCustomerID.ValueString(),
+					ReaderWorkloadIdentityConfig:                   data.ReaderWorkloadIdentityConfig.ValueString(),
+					ReaderServiceAccountCredentialsSecretPath:      data.ReaderServiceAccountCredentialsSecretPath.ValueString(),
+					ProvisionerWorkloadIdentityConfig:              data.ProvisionerWorkloadIdentityConfig.ValueString(),
+					ProvisionerServiceAccountCredentialsSecretPath: data.ProvisionerServiceAccountCredentialsSecretPath.ValueString(),
+					OrganizationId:            data.OrganizationID.ValueString(),
+					GoogleWorkspaceCustomerId: data.GoogleWorkspaceCustomerID.ValueString(),
 				},
 			},
 		},
@@ -199,12 +211,14 @@ func (r *GCPIntegrationResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	state = GCPIntegrationModel{
-		Id:                                  types.StringValue(state.Id.ValueString()),
-		Name:                                types.StringValue(res.Msg.Integration.Name),
-		WorkloadIdentityConfig:              grab.If(integ.ReaderWorkloadIdentityConfig == "", types.StringNull(), types.StringValue(integ.ReaderWorkloadIdentityConfig)),
-		ServiceAccountCredentialsSecretPath: grab.If(integ.ReaderServiceAccountCredentialsSecretPath == "", types.StringNull(), types.StringValue(integ.ReaderServiceAccountCredentialsSecretPath)),
-		OrganizationID:                      types.StringValue(integ.OrganizationId),
-		GoogleWorkspaceCustomerID:           types.StringValue(integ.GoogleWorkspaceCustomerId),
+		Id:                           types.StringValue(state.Id.ValueString()),
+		Name:                         types.StringValue(res.Msg.Integration.Name),
+		ReaderWorkloadIdentityConfig: grab.If(integ.ReaderWorkloadIdentityConfig == "", types.StringNull(), types.StringValue(integ.ReaderWorkloadIdentityConfig)),
+		ReaderServiceAccountCredentialsSecretPath:      grab.If(integ.ReaderServiceAccountCredentialsSecretPath == "", types.StringNull(), types.StringValue(integ.ReaderServiceAccountCredentialsSecretPath)),
+		ProvisionerWorkloadIdentityConfig:              grab.If(integ.ProvisionerWorkloadIdentityConfig == "", types.StringNull(), types.StringValue(integ.ProvisionerWorkloadIdentityConfig)),
+		ProvisionerServiceAccountCredentialsSecretPath: grab.If(integ.ProvisionerServiceAccountCredentialsSecretPath == "", types.StringNull(), types.StringValue(integ.ProvisionerServiceAccountCredentialsSecretPath)),
+		OrganizationID:            types.StringValue(integ.OrganizationId),
+		GoogleWorkspaceCustomerID: types.StringValue(integ.GoogleWorkspaceCustomerId),
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -237,10 +251,12 @@ func (r *GCPIntegrationResource) Update(ctx context.Context, req resource.Update
 			Config: &integrationv1alpha1.Config{
 				Config: &integrationv1alpha1.Config_Gcp{
 					Gcp: &integrationv1alpha1.GCP{
-						ReaderWorkloadIdentityConfig:              data.WorkloadIdentityConfig.ValueString(),
-						ReaderServiceAccountCredentialsSecretPath: data.ServiceAccountCredentialsSecretPath.ValueString(),
-						OrganizationId:                            data.OrganizationID.ValueString(),
-						GoogleWorkspaceCustomerId:                 data.GoogleWorkspaceCustomerID.ValueString(),
+						ReaderWorkloadIdentityConfig:                   data.ReaderWorkloadIdentityConfig.ValueString(),
+						ReaderServiceAccountCredentialsSecretPath:      data.ReaderServiceAccountCredentialsSecretPath.ValueString(),
+						ProvisionerWorkloadIdentityConfig:              data.ProvisionerWorkloadIdentityConfig.ValueString(),
+						ProvisionerServiceAccountCredentialsSecretPath: data.ProvisionerServiceAccountCredentialsSecretPath.ValueString(),
+						OrganizationId:            data.OrganizationID.ValueString(),
+						GoogleWorkspaceCustomerId: data.GoogleWorkspaceCustomerID.ValueString(),
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds additional fields for the AWS and GCP integrations to support migrating away for requiring the provisioner config to be specified in bot application config and the infrastructure.

This PR is a non breaking change, this means you can deploy an integration to start loading data before you configure the application to be able to provision access