### PR TITLE
Display error indicating that availability may have been deleted when updating a non existent availability

### DIFF
--- a/.changeset/good-actors-add.md
+++ b/.changeset/good-actors-add.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Terraform provider now displays an error message indicating that the availability may have been deleted when attempting to update a non-existent availability.

--- a/internal/auth0/resource_auth0_organization_availabilities.go
+++ b/internal/auth0/resource_auth0_organization_availabilities.go
@@ -239,7 +239,18 @@ func (r *Auth0OrganizationAvailabilitiesResource) Update(ctx context.Context, re
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"Auth0 Organization Availability Not Found",
+				"The requested Auth0 Organization Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Auth0 Organization Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/aws/resource_aws_idc_account_availabilities.go
+++ b/internal/aws/resource_aws_idc_account_availabilities.go
@@ -254,7 +254,18 @@ func (r *AWSIDCAccountAvailabilitiesResource) Update(ctx context.Context, req re
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"AWS Account Availability Not Found",
+				"The requested AWS Account Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update AWS Account Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/aws/resource_aws_idc_group_availabilities.go
+++ b/internal/aws/resource_aws_idc_group_availabilities.go
@@ -247,9 +247,20 @@ func (r *AWSIDCGroupAvailabilitiesResource) Update(ctx context.Context, req reso
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"AWS IAM group Availability Not Found",
+				"The requested AWS IAM group Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to update AWS Account Availabilities",
+			"Unable to update AWS IAM group Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+
 				"Please report this issue to the provider developers.\n\n"+
 				"JSON Error: "+err.Error(),

--- a/internal/aws/resource_aws_rds_availabilities.go
+++ b/internal/aws/resource_aws_rds_availabilities.go
@@ -252,7 +252,18 @@ func (r *AWSRDSDatabaseAvailabilitiesResource) Update(ctx context.Context, req r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"AWS RDS Availability Not Found",
+				"The requested AWS RDS Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update AWS RDS Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/datastax/resource_datastax_organization_availabilities.go
+++ b/internal/datastax/resource_datastax_organization_availabilities.go
@@ -252,7 +252,18 @@ func (r *DataStaxOrganizationAvailabilitiesResource) Update(ctx context.Context,
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"DataStax role Availability Not Found",
+				"The requested DataStax role Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update DataStax Organization Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/entra/resource_entra_group_availabilities.go
+++ b/internal/entra/resource_entra_group_availabilities.go
@@ -246,7 +246,18 @@ func (r *EntraGroupAvailabilitiesResource) Update(ctx context.Context, req resou
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"Entra Group Availability Not Found",
+				"The requested Entra Group Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Entra Group Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_bigquery_dataset_availabilities.go
+++ b/internal/gcp/resource_gcp_bigquery_dataset_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPBigQueryDatasetAvailabilitiesResource) Update(ctx context.Context, r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP BigQuery Dataset Availability Not Found",
+				"The requested GCP BigQuery Dataset Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP BigQuery Dataset Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_bigquery_table_availabilities.go
+++ b/internal/gcp/resource_gcp_bigquery_table_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPBigQueryTableAvailabilitiesResource) Update(ctx context.Context, req
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP BigQuery Table Availability Not Found",
+				"The requested GCP BigQuery Table Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP BigQuery Table Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_folder_availabilities.go
+++ b/internal/gcp/resource_gcp_folder_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPFolderAvailabilitiesResource) Update(ctx context.Context, req resour
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP Folder Availability Not Found",
+				"The requested GCP Folder Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Folder Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_organization_availabilities.go
+++ b/internal/gcp/resource_gcp_organization_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPOrganizationAvailabilitiesResource) Update(ctx context.Context, req 
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP Organization Availability Not Found",
+				"The requested GCP Organization Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Organization Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_project_availabilities.go
+++ b/internal/gcp/resource_gcp_project_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPProjectAvailabilitiesResource) Update(ctx context.Context, req resou
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP Project Availability Not Found",
+				"The requested GCP Project Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Project Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_role_group_folder_availabilities.go
+++ b/internal/gcp/resource_gcp_role_group_folder_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPRoleGroupFolderAvailabilitiesResource) Update(ctx context.Context, r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP Folder Availability Not Found",
+				"The requested GCP Folder Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Folder Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/gcp/resource_gcp_role_group_project_availabilities.go
+++ b/internal/gcp/resource_gcp_role_group_project_availabilities.go
@@ -256,7 +256,18 @@ func (r *GCPRoleGroupProjectAvailabilitiesResource) Update(ctx context.Context, 
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"GCP Project Availability Not Found",
+				"The requested GCP Project Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Project Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+

--- a/internal/generic/resource_availability_spec.go
+++ b/internal/generic/resource_availability_spec.go
@@ -245,9 +245,20 @@ func (r *AvailabilitySpecResource) Update(ctx context.Context, req resource.Upda
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"Resource Availability Not Found",
+				"The requested Resource Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to Update Resource: AvailabilitySpec",
+			"Unable to Update Resource Availability Spec",
 			"An unexpected error occurred while communicating with Common Fate API. "+
 				"Please report this issue to the provider developers.\n\n"+
 				"JSON Error: "+err.Error(),

--- a/internal/okta/resource_okta_group_availabilities.go
+++ b/internal/okta/resource_okta_group_availabilities.go
@@ -246,7 +246,18 @@ func (r *OktaGroupAvailabilitiesResource) Update(ctx context.Context, req resour
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if err != nil {
+	if connectErr, ok := err.(*connect.Error); ok {
+		if connectErr.Code() == connect.CodeNotFound {
+			resp.Diagnostics.AddError(
+				"Okta Group Availability Not Found",
+				"The requested Okta Group Availability no longer exists. "+
+					"It may have been deleted or otherwise removed.\n"+
+					"Please create a new Availability.",
+			)
+
+			return
+		}
+	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Okta Group Availabilities",
 			"An unexpected error occurred while communicating with Common Fate API. "+


### PR DESCRIPTION
Initially tried to fulfill this requirement of the ticket:
```
Ideally, if we get a 404 error we should just recreate the availability and save the new ID in the state.
```

However, understandably ran into :
```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to commonfate_auth0_organization_availabilities.auth0, provider "provider[\"registry.terraform.io/common-fate/commonfate\"]" produced
│ an unexpected new value: .id: was cty.StringVal("avspec_2jj7XNb87FSBLQfVbhesGE1RzwH"), but now cty.StringVal("avspec_2jj7tnQP6dNZjoFMsUvhHmELm2c").
```

Therefore, opting to change the error message instead.

Reproducing the error now gives:

```
│ Error: Auth0 Organization Availability Not Found
│ 
│   with commonfate_auth0_organization_availabilities.auth0,
│   on main.tf line 278, in resource "commonfate_auth0_organization_availabilities" "auth0":
│  278: resource "commonfate_auth0_organization_availabilities" "auth0" {
│ 
│ The requested Auth0 Organization Availability no longer exists. It may have been deleted or otherwise removed.
│ Please create a new Availability.
```