### PR TITLE
Return error when proxy is not found using the datasource

### DIFF
--- a/internal/proxy/datasource_ecs_proxy.go
+++ b/internal/proxy/datasource_ecs_proxy.go
@@ -120,6 +120,10 @@ func (r *ECSProxyDatasource) Read(ctx context.Context, req datasource.ReadReques
 	}))
 	if connect.CodeOf(err) == connect.CodeNotFound {
 		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"Proxy not found",
+			err.Error(),
+		)
 		return
 	} else if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
![Screenshot 2024-09-06 at 10 34 38 AM](https://github.com/user-attachments/assets/ca0959ab-3570-48c8-b476-2a2368540f99)

Previously the datasource would return a null object causing an unexpected error. Now it will return a typed not found error when this occurs