### PR TITLE
add check for idstore not empty when creating aws availabilities

### DIFF
--- a/internal/aws/resource_aws_idc_account_availabilities.go
+++ b/internal/aws/resource_aws_idc_account_availabilities.go
@@ -124,6 +124,14 @@ func (r *AWSIDCAccountAvailabilitiesResource) Create(ctx context.Context, req re
 
 		return
 	}
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
+		)
+
+		return
+	}
 
 	input := &configv1alpha1.CreateAvailabilitySpecRequest{
 		Role: &entityv1alpha1.EID{
@@ -224,6 +232,15 @@ func (r *AWSIDCAccountAvailabilitiesResource) Update(ctx context.Context, req re
 		resp.Diagnostics.AddError(
 			"Unable to read plan data into model",
 			"An unexpected error occurred while parsing the resource creation response.",
+		)
+
+		return
+	}
+
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
 		)
 
 		return

--- a/internal/aws/resource_aws_idc_group_availabilities.go
+++ b/internal/aws/resource_aws_idc_group_availabilities.go
@@ -119,6 +119,14 @@ func (r *AWSIDCGroupAvailabilitiesResource) Create(ctx context.Context, req reso
 
 		return
 	}
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
+		)
+
+		return
+	}
 
 	input := &configv1alpha1.CreateAvailabilitySpecRequest{
 		Role: &entityv1alpha1.EID{
@@ -218,6 +226,15 @@ func (r *AWSIDCGroupAvailabilitiesResource) Update(ctx context.Context, req reso
 		resp.Diagnostics.AddError(
 			"Unable to read plan data into model",
 			"An unexpected error occurred while parsing the resource creation response.",
+		)
+
+		return
+	}
+
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
 		)
 
 		return

--- a/internal/aws/resource_aws_rds_availabilities.go
+++ b/internal/aws/resource_aws_rds_availabilities.go
@@ -124,6 +124,15 @@ func (r *AWSRDSDatabaseAvailabilitiesResource) Create(ctx context.Context, req r
 		return
 	}
 
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
+		)
+
+		return
+	}
+
 	input := &configv1alpha1.CreateAvailabilitySpecRequest{
 		Role: &entityv1alpha1.EID{
 			Type: "AWS::RDS::DatabaseUser",
@@ -223,6 +232,15 @@ func (r *AWSRDSDatabaseAvailabilitiesResource) Update(ctx context.Context, req r
 		resp.Diagnostics.AddError(
 			"Unable to read plan data into model",
 			"An unexpected error occurred while parsing the resource creation response.",
+		)
+
+		return
+	}
+
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
 		)
 
 		return

--- a/internal/aws/resource_aws_rds_availability.go
+++ b/internal/aws/resource_aws_rds_availability.go
@@ -124,6 +124,15 @@ func (r *AWSRDSDatabaseAvailabilityResource) Create(ctx context.Context, req res
 		return
 	}
 
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
+		)
+
+		return
+	}
+
 	input := &configv1alpha1.CreateAvailabilitySpecRequest{
 		Role: &entityv1alpha1.EID{
 			Type: "AWS::RDS::DatabaseUser",
@@ -196,6 +205,15 @@ func (r *AWSRDSDatabaseAvailabilityResource) Read(ctx context.Context, req resou
 		return
 	}
 
+	if state.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
+		)
+
+		return
+	}
+
 	state.ID = types.StringValue(res.Msg.AvailabilitySpec.Id)
 	state.WorkflowID = types.StringValue(res.Msg.AvailabilitySpec.WorkflowId)
 	state.AWSRDSDatabaseID = types.StringValue(res.Msg.AvailabilitySpec.Target.Id)
@@ -223,6 +241,15 @@ func (r *AWSRDSDatabaseAvailabilityResource) Update(ctx context.Context, req res
 		resp.Diagnostics.AddError(
 			"Unable to read plan data into model",
 			"An unexpected error occurred while parsing the resource creation response.",
+		)
+
+		return
+	}
+
+	if data.AWSIdentityStoreID.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"aws_identity_store_id empty",
+			"aws_identity_store_id cannot be empty.",
 		)
 
 		return


### PR DESCRIPTION
Adds extra validation to the AWS availability spec resources to make sure users cannot create availability specs with empty identity store id's.

This will minimise users experiencing issues when applying access to these resources.