### PR TITLE
Fix typed connect error handling in update resource

### DIFF
--- a/.changeset/chilled-phones-report.md
+++ b/.changeset/chilled-phones-report.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": patch
+---
+
+Fix issue causing typed connect errors to not be handled correctly in the update method of some resources

--- a/internal/auth0/resource_auth0_organization_availabilities.go
+++ b/internal/auth0/resource_auth0_organization_availabilities.go
@@ -239,17 +239,17 @@ func (r *Auth0OrganizationAvailabilitiesResource) Update(ctx context.Context, re
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"Auth0 Organization Availability Not Found",
-				"The requested Auth0 Organization Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"Auth0 Organization Availability Not Found",
+			"The requested Auth0 Organization Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Auth0 Organization Availabilities",

--- a/internal/aws/resource_aws_idc_account_availabilities.go
+++ b/internal/aws/resource_aws_idc_account_availabilities.go
@@ -254,17 +254,17 @@ func (r *AWSIDCAccountAvailabilitiesResource) Update(ctx context.Context, req re
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"AWS Account Availability Not Found",
-				"The requested AWS Account Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"AWS Account Availability Not Found",
+			"The requested AWS Account Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update AWS Account Availabilities",

--- a/internal/aws/resource_aws_idc_group_availabilities.go
+++ b/internal/aws/resource_aws_idc_group_availabilities.go
@@ -247,17 +247,17 @@ func (r *AWSIDCGroupAvailabilitiesResource) Update(ctx context.Context, req reso
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"AWS IAM group Availability Not Found",
-				"The requested AWS IAM group Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"AWS IAM group Availability Not Found",
+			"The requested AWS IAM group Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update AWS IAM group Availabilities",

--- a/internal/aws/resource_aws_rds_availabilities.go
+++ b/internal/aws/resource_aws_rds_availabilities.go
@@ -252,17 +252,17 @@ func (r *AWSRDSDatabaseAvailabilitiesResource) Update(ctx context.Context, req r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"AWS RDS Availability Not Found",
-				"The requested AWS RDS Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"AWS RDS Availability Not Found",
+			"The requested AWS RDS Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update AWS RDS Availabilities",

--- a/internal/aws/resource_aws_rds_availability.go
+++ b/internal/aws/resource_aws_rds_availability.go
@@ -252,20 +252,19 @@ func (r *AWSRDSDatabaseAvailabilityResource) Update(ctx context.Context, req res
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"AWS RDS Availability Not Found",
-				"The requested AWS RDS Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
 
-			return
-		}
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
+		resp.Diagnostics.AddError(
+			"AWS RDS Availability Not Found",
+			"The requested AWS RDS Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
 	} else if err != nil {
 		resp.Diagnostics.AddError(
-			"Unable to update AWS RDS Availabilities",
+			"Unable to update AWS RDS Availability",
 			"An unexpected error occurred while communicating with Common Fate API. "+
 				"Please report this issue to the provider developers.\n\n"+
 				"JSON Error: "+err.Error(),

--- a/internal/datastax/resource_datastax_organization_availabilities.go
+++ b/internal/datastax/resource_datastax_organization_availabilities.go
@@ -252,17 +252,17 @@ func (r *DataStaxOrganizationAvailabilitiesResource) Update(ctx context.Context,
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"DataStax role Availability Not Found",
-				"The requested DataStax role Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"DataStax role Availability Not Found",
+			"The requested DataStax role Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update DataStax Organization Availabilities",

--- a/internal/entra/resource_entra_group_availabilities.go
+++ b/internal/entra/resource_entra_group_availabilities.go
@@ -246,17 +246,16 @@ func (r *EntraGroupAvailabilitiesResource) Update(ctx context.Context, req resou
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"Entra Group Availability Not Found",
-				"The requested Entra Group Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"Entra Group Availability Not Found",
+			"The requested Entra Group Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Entra Group Availabilities",

--- a/internal/gcp/resource_gcp_bigquery_dataset_availabilities.go
+++ b/internal/gcp/resource_gcp_bigquery_dataset_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPBigQueryDatasetAvailabilitiesResource) Update(ctx context.Context, r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP BigQuery Dataset Availability Not Found",
-				"The requested GCP BigQuery Dataset Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP BigQuery Dataset Availability Not Found",
+			"The requested GCP BigQuery Dataset Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP BigQuery Dataset Availabilities",

--- a/internal/gcp/resource_gcp_bigquery_table_availabilities.go
+++ b/internal/gcp/resource_gcp_bigquery_table_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPBigQueryTableAvailabilitiesResource) Update(ctx context.Context, req
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP BigQuery Table Availability Not Found",
-				"The requested GCP BigQuery Table Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP BigQuery Table Availability Not Found",
+			"The requested GCP BigQuery Table Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP BigQuery Table Availabilities",

--- a/internal/gcp/resource_gcp_folder_availabilities.go
+++ b/internal/gcp/resource_gcp_folder_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPFolderAvailabilitiesResource) Update(ctx context.Context, req resour
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP Folder Availability Not Found",
-				"The requested GCP Folder Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP Folder Availability Not Found",
+			"The requested GCP Folder Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Folder Availabilities",

--- a/internal/gcp/resource_gcp_organization_availabilities.go
+++ b/internal/gcp/resource_gcp_organization_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPOrganizationAvailabilitiesResource) Update(ctx context.Context, req 
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP Organization Availability Not Found",
-				"The requested GCP Organization Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP Organization Availability Not Found",
+			"The requested GCP Organization Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Organization Availabilities",

--- a/internal/gcp/resource_gcp_project_availabilities.go
+++ b/internal/gcp/resource_gcp_project_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPProjectAvailabilitiesResource) Update(ctx context.Context, req resou
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP Project Availability Not Found",
-				"The requested GCP Project Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP Project Availability Not Found",
+			"The requested GCP Project Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Project Availabilities",

--- a/internal/gcp/resource_gcp_role_group_folder_availabilities.go
+++ b/internal/gcp/resource_gcp_role_group_folder_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPRoleGroupFolderAvailabilitiesResource) Update(ctx context.Context, r
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP Folder Availability Not Found",
-				"The requested GCP Folder Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP Folder Availability Not Found",
+			"The requested GCP Folder Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Folder Availabilities",

--- a/internal/gcp/resource_gcp_role_group_project_availabilities.go
+++ b/internal/gcp/resource_gcp_role_group_project_availabilities.go
@@ -256,17 +256,17 @@ func (r *GCPRoleGroupProjectAvailabilitiesResource) Update(ctx context.Context, 
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"GCP Project Availability Not Found",
-				"The requested GCP Project Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"GCP Project Availability Not Found",
+			"The requested GCP Project Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update GCP Project Availabilities",

--- a/internal/generic/resource_availability_spec.go
+++ b/internal/generic/resource_availability_spec.go
@@ -245,17 +245,17 @@ func (r *AvailabilitySpecResource) Update(ctx context.Context, req resource.Upda
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"Resource Availability Not Found",
-				"The requested Resource Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"Resource Availability Not Found",
+			"The requested Resource Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Update Resource Availability Spec",

--- a/internal/okta/resource_okta_group_availabilities.go
+++ b/internal/okta/resource_okta_group_availabilities.go
@@ -246,17 +246,17 @@ func (r *OktaGroupAvailabilitiesResource) Update(ctx context.Context, req resour
 	res, err := r.client.AvailabilitySpec().UpdateAvailabilitySpec(ctx, connect.NewRequest(&configv1alpha1.UpdateAvailabilitySpecRequest{
 		AvailabilitySpec: input,
 	}))
-	if connectErr, ok := err.(*connect.Error); ok {
-		if connectErr.Code() == connect.CodeNotFound {
-			resp.Diagnostics.AddError(
-				"Okta Group Availability Not Found",
-				"The requested Okta Group Availability no longer exists. "+
-					"It may have been deleted or otherwise removed.\n"+
-					"Please create a new Availability.",
-			)
+	if connectErr, ok := err.(*connect.Error); ok && connectErr.Code() == connect.CodeNotFound {
 
-			return
-		}
+		resp.Diagnostics.AddError(
+			"Okta Group Availability Not Found",
+			"The requested Okta Group Availability no longer exists. "+
+				"It may have been deleted or otherwise removed.\n"+
+				"Please create a new Availability.",
+		)
+
+		return
+
 	} else if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Okta Group Availabilities",


### PR DESCRIPTION
I found that when sending a typed connect error message to the update method of our provider resources we were incorrectly handling the errors which caused a nil pointer in the update method.

Because the existing logic only checks for `connectErr.Code() == connect.CodeNotFound` and disregards any other typed connect errors, the error handling would be skipped.

This PR updates the handling to handle typed errors correctly.