### PR TITLE
Josh/cf 3611 allow multi stage approvals

### DIFF
--- a/.changeset/good-beers-occur.md
+++ b/.changeset/good-beers-occur.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-provider-commonfate": minor
+---
+
+Adds support for configuring approval steps on a workflow, which enables multi approval requirements for Grants.

--- a/docs/resources/access_workflow.md
+++ b/docs/resources/access_workflow.md
@@ -46,6 +46,7 @@ resource "commonfate-access_workflow" "workflow-demo" {
 ### Optional
 
 - `activation_expiry` (Number) The amount of time after access is activated before the request will be expired
+- `approval_steps` (Attributes List) Define the requirements for grant approval, each step must be completed by a distict principal, steps can be completed in any order. (see [below for nested schema](#nestedatt--approval_steps))
 - `default_duration_seconds` (Number) The default duration of the access workflow
 - `extension_conditions` (Attributes) Configuration for extending access (see [below for nested schema](#nestedatt--extension_conditions))
 - `name` (String) A unique name for the workflow so you know how to identify it.
@@ -56,6 +57,15 @@ resource "commonfate-access_workflow" "workflow-demo" {
 ### Read-Only
 
 - `id` (String) The internal approval workflow ID
+
+<a id="nestedatt--approval_steps"></a>
+### Nested Schema for `approval_steps`
+
+Required:
+
+- `name` (String) The name of the approval step.
+- `when` (String) The Cedar when expression to evaluate a review for a match.
+
 
 <a id="nestedatt--extension_conditions"></a>
 ### Nested Schema for `extension_conditions`

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6
+	github.com/common-fate/sdk v1.63.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.4
 require (
 	connectrpc.com/connect v1.14.0
 	github.com/common-fate/grab v1.1.0
-	github.com/common-fate/sdk v1.60.0
+	github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/common-fate/sdk v1.59.3-0.20240930041650-9dff9f8c434c h1:fXiW8om7V+0G
 github.com/common-fate/sdk v1.59.3-0.20240930041650-9dff9f8c434c/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
 github.com/common-fate/sdk v1.60.0 h1:Ebh9SfCoA/2dArKDMlw89rgfmNYVWUqJY0J5gNxRsgc=
 github.com/common-fate/sdk v1.60.0/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
+github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6 h1:Y5VvsG4+byDP5AlVoXM2h8izSvN7WDLGvTeuHdiczmA=
+github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/common-fate/sdk v1.60.0 h1:Ebh9SfCoA/2dArKDMlw89rgfmNYVWUqJY0J5gNxRsg
 github.com/common-fate/sdk v1.60.0/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
 github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6 h1:Y5VvsG4+byDP5AlVoXM2h8izSvN7WDLGvTeuHdiczmA=
 github.com/common-fate/sdk v1.61.1-0.20241003003332-71be03ac64a6/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
+github.com/common-fate/sdk v1.63.0 h1:Nlgf3jpoJVy7DR3QhKvkZW3LYUyWXT5oDBpF3h/Xtjs=
+github.com/common-fate/sdk v1.63.0/go.mod h1:OrXhzB2Y1JSrKGHrb4qRmY+6MF2M3MFb+3edBnessXo=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/internal/access/resource_access_workflow.go
+++ b/internal/access/resource_access_workflow.go
@@ -384,7 +384,7 @@ func (r *AccessWorkflowResource) Read(ctx context.Context, req resource.ReadRequ
 		}
 	}
 
-	state.ApprovalSteps = []ApprovalStep{}
+	state.ApprovalSteps = nil
 	for _, step := range res.Msg.Workflow.ApprovalSteps {
 		state.ApprovalSteps = append(state.ApprovalSteps, ApprovalStep{
 			Name: types.StringValue(step.Name),

--- a/internal/access/resource_access_workflow.go
+++ b/internal/access/resource_access_workflow.go
@@ -285,7 +285,7 @@ func (r *AccessWorkflowResource) Create(ctx context.Context, req resource.Create
 	for _, step := range data.ApprovalSteps {
 		createReq.ApprovalSteps = append(createReq.ApprovalSteps, &configv1alpha1.ApprovalStep{
 			Name: step.Name.ValueString(),
-			When: step.Name.ValueString(),
+			When: step.When.ValueString(),
 		})
 	}
 
@@ -480,7 +480,7 @@ func (r *AccessWorkflowResource) Update(ctx context.Context, req resource.Update
 	for _, step := range data.ApprovalSteps {
 		updateReq.Workflow.ApprovalSteps = append(updateReq.Workflow.ApprovalSteps, &configv1alpha1.ApprovalStep{
 			Name: step.Name.ValueString(),
-			When: step.Name.ValueString(),
+			When: step.When.ValueString(),
 		})
 	}
 


### PR DESCRIPTION
Adds support for configuring the approvals steps on a workflow.
This enables requiring multi stage approvals for a grant, where each step must be completed by a different reviewer.

When configured, a Grant will not be marked as approved until each step has been completed.
Currently, the steps can be completed in any order.

The When field is a Cedar expression which operates over the entity type where the action is Access::Action::"Approve", the principal is the reviewer, and the resource is an entity as below.
```
{
  principal: the reviewer
  grant: the access grant
}
```

```
resource "commonfate_access_workflow" "aws" {
  name                    = "aws"
  access_duration_seconds = 60 * 60 * 24 * 7
  priority                = 200
  activation_expiry       = 60 * 60 * 8

  approval_steps = [{
    name = "Approval from Josh"
    when = <<EOF
  principal == CF::User::"usr_2gTtRsriXMqAM5kA3FPEygX0HG7"
  EOF
    },
    {
      name = "Another Apporoval is Required from one of the Security Team"
      when = <<EOF
  principal in Entra::Group::"Security"
  EOF
  }]

}
```